### PR TITLE
integration tests for array rpcs

### DIFF
--- a/vistalink-tests/src/main/docker/entrypoint.sh
+++ b/vistalink-tests/src/main/docker/entrypoint.sh
@@ -15,6 +15,7 @@ java-tests \
   --regression-test-pattern ".*IT\$" \
   --smoke-test-pattern ".*PingIT\$" \
   -Dsentinel="$SENTINEL_ENV" \
+  -Dvistalink.url=$VISTALINK_URL \
   -Dvista.access-code="$VISTA_ACCESS_CODE" \
   -Dvista.verify-code="$VISTA_VERIFY_CODE" \
   $@

--- a/vistalink-tests/src/main/java/gov/va/api/lighthouse/vistalink/tests/SystemDefinitions.java
+++ b/vistalink-tests/src/main/java/gov/va/api/lighthouse/vistalink/tests/SystemDefinitions.java
@@ -56,6 +56,20 @@ public class SystemDefinitions {
                 .name("XOBV TEST STRING")
                 .parameters(List.of(Parameter.builder().string("SHANKTOPUS GO!").build()))
                 .build())
+        .globalArrayRequestRpc(
+            RpcDetails.builder()
+                .context("XOBV VISTALINK TESTER")
+                .name("XOBV TEST GLOBAL ARRAY")
+                .parameters(
+                    List.of(Parameter.builder().array(List.of("GLOBAL", "SHANKTOPUS")).build()))
+                .build())
+        .localArrayRequestRpc(
+            RpcDetails.builder()
+                .context("XOBV VISTALINK TESTER")
+                .name("XOBV TEST LOCAL ARRAY")
+                .parameters(
+                    List.of(Parameter.builder().array(List.of("LOCAL", "SHANKTOPUS")).build()))
+                .build())
         .build();
   }
 

--- a/vistalink-tests/src/main/java/gov/va/api/lighthouse/vistalink/tests/TestClients.java
+++ b/vistalink-tests/src/main/java/gov/va/api/lighthouse/vistalink/tests/TestClients.java
@@ -7,10 +7,8 @@ import gov.va.api.health.sentinel.TestClient;
 import gov.va.api.lighthouse.vistalink.service.api.RpcRequest;
 import java.util.Map;
 import lombok.experimental.UtilityClass;
-import lombok.extern.slf4j.Slf4j;
 
 @UtilityClass
-@Slf4j
 public class TestClients {
   ExpectedResponse rpcRequest(String path, RpcRequest body) {
     return TestClients.vistalink().post(Map.of("Content-Type", "application/json"), path, body);

--- a/vistalink-tests/src/main/java/gov/va/api/lighthouse/vistalink/tests/TestClients.java
+++ b/vistalink-tests/src/main/java/gov/va/api/lighthouse/vistalink/tests/TestClients.java
@@ -13,7 +13,6 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class TestClients {
   ExpectedResponse rpcRequest(String path, RpcRequest body) {
-    log.info("Request path is: {}", path);
     return TestClients.vistalink().post(Map.of("Content-Type", "application/json"), path, body);
   }
 

--- a/vistalink-tests/src/main/java/gov/va/api/lighthouse/vistalink/tests/TestRpcs.java
+++ b/vistalink-tests/src/main/java/gov/va/api/lighthouse/vistalink/tests/TestRpcs.java
@@ -10,4 +10,6 @@ import lombok.Value;
 public class TestRpcs {
   @NotNull RpcDetails pingRpc;
   @NotNull RpcDetails stringRequestRpc;
+  @NotNull RpcDetails localArrayRequestRpc;
+  @NotNull RpcDetails globalArrayRequestRpc;
 }

--- a/vistalink-tests/src/test/java/gov/va/api/lighthouse/vistalink/tests/VistalinkRequestIT.java
+++ b/vistalink-tests/src/test/java/gov/va/api/lighthouse/vistalink/tests/VistalinkRequestIT.java
@@ -2,6 +2,7 @@ package gov.va.api.lighthouse.vistalink.tests;
 
 import static org.junit.Assume.assumeTrue;
 
+import gov.va.api.lighthouse.vistalink.service.api.RpcDetails;
 import gov.va.api.lighthouse.vistalink.service.api.RpcRequest;
 import gov.va.api.lighthouse.vistalink.service.api.RpcResponse;
 import lombok.SneakyThrows;
@@ -11,16 +12,28 @@ import org.junit.jupiter.api.Test;
 @Slf4j
 public class VistalinkRequestIT {
 
+  private static SystemDefinition systemDefinition = SystemDefinitions.get();
+
   @Test
-  @SneakyThrows
+  void requestRpcWithGlobalArrayArgument() {
+    requestRpcWithValidResponse(systemDefinition.testRpcs().globalArrayRequestRpc());
+  }
+
+  @Test
+  void requestRpcWithLocalArrayArgument() {
+    requestRpcWithValidResponse(systemDefinition.testRpcs().localArrayRequestRpc());
+  }
+
+  @Test
   void requestRpcWithStringArgument() {
-    var systemDefinition = SystemDefinitions.get();
+    requestRpcWithValidResponse(systemDefinition.testRpcs().stringRequestRpc());
+  }
+
+  @SneakyThrows
+  void requestRpcWithValidResponse(RpcDetails rpc) {
     assumeTrue(systemDefinition.isVistalinkAvailable());
     RpcRequest body =
-        RpcRequest.builder()
-            .rpc(systemDefinition.testRpcs().stringRequestRpc())
-            .principal(systemDefinition.testRpcPrincipal())
-            .build();
+        RpcRequest.builder().rpc(rpc).principal(systemDefinition.testRpcPrincipal()).build();
     var response =
         TestClients.rpcRequest(systemDefinition.vistalink().apiPath() + "rpc", body)
             .expect(200)

--- a/vistalink-tests/src/test/java/gov/va/api/lighthouse/vistalink/tests/VistalinkRequestIT.java
+++ b/vistalink-tests/src/test/java/gov/va/api/lighthouse/vistalink/tests/VistalinkRequestIT.java
@@ -32,6 +32,7 @@ public class VistalinkRequestIT {
   @SneakyThrows
   void requestRpcWithValidResponse(RpcDetails rpc) {
     assumeTrue(systemDefinition.isVistalinkAvailable());
+    log.info(rpc.name());
     RpcRequest body =
         RpcRequest.builder().rpc(rpc).principal(systemDefinition.testRpcPrincipal()).build();
     var response =


### PR DESCRIPTION
I was unable to find an RPC in the test context for a ref argument, so there is no integration test for refs.