### PR TITLE
API-000-allow-null-paramters

### DIFF
--- a/vistalink/src/main/java/gov/va/api/lighthouse/vistalink/service/api/RpcDetails.java
+++ b/vistalink/src/main/java/gov/va/api/lighthouse/vistalink/service/api/RpcDetails.java
@@ -62,14 +62,15 @@ public class RpcDetails {
       if (array != null) {
         count++;
       }
-      if (count != 1) {
+      // A null value can be valid in a longer sequence, so 0 is also valid
+      if (count > 1) {
         throw new IllegalArgumentException("Exact one of ref, string, or array must be specified");
       }
     }
 
     @Override
     public String toString() {
-      return getClass().getSimpleName() + "(" + type() + "=" + value() + ")";
+      return getClass().getSimpleName() + "(" + type() + "=" + value().orElse("unset") + ")";
     }
 
     /** Determine RPC parameter type based on the fields that are set. */
@@ -83,21 +84,20 @@ public class RpcDetails {
       if (array != null) {
         return "array";
       }
-      throw new IllegalStateException("unknown type");
+      return "unknown";
     }
 
     /** Determine RPC parameter value based on the fields that are set. */
-    public Object value() {
+    public Optional<Object> value() {
+      Object value = null;
       if (ref != null) {
-        return ref;
+        value = ref;
+      } else if (string != null) {
+        value = string;
+      } else if (array != null) {
+        value = array;
       }
-      if (string != null) {
-        return string;
-      }
-      if (array != null) {
-        return array;
-      }
-      throw new IllegalStateException("unknown type");
+      return Optional.ofNullable(value);
     }
   }
 }

--- a/vistalink/src/main/java/gov/va/api/lighthouse/vistalink/service/controller/VistalinkRpcInvoker.java
+++ b/vistalink/src/main/java/gov/va/api/lighthouse/vistalink/service/controller/VistalinkRpcInvoker.java
@@ -153,7 +153,11 @@ public class VistalinkRpcInvoker implements RpcInvoker {
       }
       for (int i = 0; i < rpcDetails.parameters().size(); i++) {
         var parameter = rpcDetails.parameters().get(i);
-        vistalinkRequest.getParams().setParam(i + 1, parameter.type(), parameter.value());
+        var index = i;
+        parameter
+            .value()
+            .ifPresent(
+                value -> vistalinkRequest.getParams().setParam(index + 1, parameter.type(), value));
       }
       RpcResponse vistalinkResponse = invoke(vistalinkRequest);
       log.info("{} Response {} chars", this, vistalinkResponse.getRawResponse().length());


### PR DESCRIPTION
# [API-000](https://vajira.max.gov/browse/API-000)
- Sets rpc parameters that come in as null to empty - Only sets parameters that exist in the Vista RPC Request sequence